### PR TITLE
docs: Fix simple typo, proccesing -> processing

### DIFF
--- a/pyramid_sms/outgoing.py
+++ b/pyramid_sms/outgoing.py
@@ -34,7 +34,7 @@ if HAS_WEBSAUNA:
     # TODO: Factor this to a separate configurable module
     @task(base=ScheduleOnCommitTask, bind=True)
     def _send_sms_async(self, receiver, from_, text_body, log_failure):
-        """Celery task to send the SMS synchronously outside HTTP request proccesing."""
+        """Celery task to send the SMS synchronously outside HTTP request processing."""
         request = self.request.request
         _send_sms(request, receiver, from_, text_body, log_failure)
 


### PR DESCRIPTION
There is a small typo in pyramid_sms/outgoing.py.

Should read `processing` rather than `proccesing`.

